### PR TITLE
Fix: Calling node_save() may trip form_builder.

### DIFF
--- a/webform_custom_buttons.module
+++ b/webform_custom_buttons.module
@@ -100,14 +100,9 @@ function webform_custom_buttons_form_form_builder_webform_save_form_alter(&$form
 function webform_custom_buttons_webform_save_form_submit($form, &$form_state) {
   $node =  $form['#node'];
   $values = &$form_state['values'];
-  $changed = FALSE;
   foreach (array('submit_text', 'first_button_text', 'next_button_text') as $name) {
     if (!isset($node->webform[$name]) || $node->webform[$name] != $values[$name]) {
-      $changed = TRUE;
       $node->webform[$name] = $values[$name];
     }
-  }
-  if ($changed) {
-    node_save($node);
   }
 }


### PR DESCRIPTION
This fixes a bug that’s triggered whenever an existing webform component is deleted in form_builder *and* some submit button labels are changed.

The deleted `node_save()` is not needed anymore since form_builder≥7.x-1.14 because then its submit-handler also uses `$form['#node']` to save the node.

form_builder is only a soft-dependency of this module. There is no way in Drupal to specify version ranges for soft-dependencies.